### PR TITLE
Add possibility to use serial over network

### DIFF
--- a/Elelabs_EzspFwUtility.py
+++ b/Elelabs_EzspFwUtility.py
@@ -226,6 +226,7 @@ class EzspProtocolInterface:
         self.VERSION = b'\x00'
         self.GET_VALUE = b'\xAA'
         self.GET_MFG_TOKEN = b'\x0B'
+        self.SET_MFG_TOKEN = b'\x0C'
         self.LAUNCH_STANDALONE_BOOTLOADER = b'\x8F'
 
         self.EZSP_VALUE_VERSION_INFO = 0x11
@@ -285,6 +286,13 @@ class EzspProtocolInterface:
         tokenDataLength = resp[5]
         tokenData = resp[6:]
         return tokenDataLength, tokenData
+
+    def setMfgToken(self, tokenId, tokenString):
+        mfg_token_str_16bytes = bytearray([0xFF] * 16)
+
+        for i in range(0, len(tokenString)):
+            mfg_token_str_16bytes[i] = ord(tokenString[i])
+        self.sendEzspCommand(self.SET_MFG_TOKEN + bytearray([tokenId]) + bytearray([16]) + mfg_token_str_16bytes, 'setTokenString: %s' % tokenString)
 
     def launchStandaloneBootloader(self, mode, modeName):
         resp = self.sendEzspCommand(self.LAUNCH_STANDALONE_BOOTLOADER + bytearray([mode]), 'launchStandaloneBootloader: %s' % modeName)
@@ -548,18 +556,19 @@ class ElelabsUtilities:
                 self.logger.info('EZSP status returned %d' % status)
 
             token_data_length, token_data = ezsp.getMfgToken(ezsp.EZSP_MFG_STRING, "EZSP_MFG_STRING")
-            if token_data.decode("ascii", "ignore") == "Elelabs":
-                token_data_length, token_data = ezsp.getMfgToken(ezsp.EZSP_MFG_BOARD_NAME, "EZSP_MFG_BOARD_NAME")
-                adapter_name = token_data.decode("ascii", "ignore")
+            manuf_name = token_data.decode("ascii", "ignore")
+            token_data_length, token_data = ezsp.getMfgToken(ezsp.EZSP_MFG_BOARD_NAME, "EZSP_MFG_BOARD_NAME")
+            adapter_name = token_data.decode("ascii", "ignore")
 
-                self.logger.info("Elelabs Zigbee adapter detected:")
-                self.logger.info("Adapter: %s" % adapter_name)
-            else:
-                adapter_name = None
-                self.logger.info("Generic Zigbee EZSP adapter detected:")
-
+            self.logger.info("Elelabs Zigbee adapter detected:")
+            self.logger.info("Adapter: %s" % adapter_name)
+            self.logger.info("Manufacturer: %s" % manuf_name)
             self.logger.info("Firmware: %s" % firmware_version)
             self.logger.info("EZSP v%d" % ezsp.ezspVersion)
+
+            # TODO: Move somewhere
+            ezsp.setMfgToken(ezsp.EZSP_MFG_STRING, "KStrehlau")
+            ezsp.setMfgToken(ezsp.EZSP_MFG_BOARD_NAME, "ZigbeeGateway")
 
             serialInterface.close()
             return AdapterModeProbeStatus.ZIGBEE, adapter_name
@@ -780,9 +789,6 @@ class ElelabsUtilities:
             self.logger.critical("The product not in the normal EZSP mode.\r\n'restart' into normal mode or use 'flash' utility instead")
         else:
             self.logger.critical("No upgradable device found")
-
-
-
 
 args = parser.parse_args()
 

--- a/Elelabs_EzspFwUtility.py
+++ b/Elelabs_EzspFwUtility.py
@@ -52,6 +52,7 @@ parser_flash.add_argument('-f', '--file', type=lambda x: is_valid_file(parser, x
 parser_flash.add_argument('-p','--port', type=str, required=True, help='Serial port for the EZSP Product')
 parser_flash.add_argument('-b','--baudrate', type=str, required=False, default=115200, help='Serial baud rate for NCP (115200/57600)')
 parser_flash.add_argument('-d','--dlevel', choices=['RAW', 'PACKET', 'DEBUG', 'INFO'], required=False, default='INFO', help='Debug verbosity level')
+parser_flash.add_argument('-m','--mode', choices=['xmodem', 'autobtl'], required=False, default='autobtl', help='Required operation mode. Xmodem does not restart the device')
 parser_flash.set_defaults(which='flash')
 
 parser_ele_update = subparsers.add_parser('ele_update', help='Updates the Elelabs product to a latest available version')
@@ -613,7 +614,7 @@ class ElelabsUtilities:
         adapter_status, adapter_name = self.probe()
         if adapter_status == AdapterModeProbeStatus.ZIGBEE or adapter_status == AdapterModeProbeStatus.THREAD:
             if mode == 'btl':
-                serialInterface = SerialInterface(self.config.port, self.config.baudrate)
+                serialInterface = SerialInterface(self.config.port, self.config.baudrate, self.logger)
                 serialInterface.open()
 
                 self.logger.info("Launch in bootloader mode")
@@ -673,7 +674,7 @@ class ElelabsUtilities:
                 else:
                     return -1
 
-    def flash(self, filename):
+    def flash(self, filename, mode):
         # STATIC FUNCTIONS
         def getc(size, timeout=1):
             read_data = self.serialInterface.serial.read(size)
@@ -692,7 +693,7 @@ class ElelabsUtilities:
             self.logger.critical('Aborted! Gecko bootloader accepts .gbl or .ebl images only.')
             return
 
-        if self.restart("btl"):
+        if mode == 'autobtl' and not self.restart("btl"):
             self.logger.critical("EZSP adapter not in the bootloader mode. Can't perform update procedure")
             return
 
@@ -807,7 +808,7 @@ if args.which == 'ele_update':
     elelabs.ele_update(args.version)
 
 if args.which == 'flash':
-    elelabs.flash(args.file)
+    elelabs.flash(args.file, args.mode)
 
 
 


### PR DESCRIPTION
**ABOUT THIS PR**
I've been working on my own [Zigbee Gateway project](https://hackaday.io/project/194721) and this script was really helpful in context of flashing. However, as my project is ESP32S3 based I preferred to use WiFi and that's why I've modiffied this script to support over-the-air flashing.

Changes done within this PR:
- added Serial Over Socket support, use 'socket://' in as prefix for Serial Port Name ```-p socket://<ip or local domain>:<port>```
- added mode parameter '-m','--mode' which deaults to 'autobtl' (auto bootloader), the other mode is 'xmodem' (see below for details)

Few words aboutr -m / --mode:
- Elelabs modules can be reset via NCP command ('autobtl' mode), which means whole flow will be handled automatically
- There are some other modules on the market which can be reset using external pin (that's why there's XMODEM mode)
- In case of external pin, the 'xmodem' mode tells the script to skip all the probing and try to flash immediately

**EXAMPLES:**
- Flashing the module with exposed xmodem interface on target serial port
```
python Elelabs_EzspFwUtility.py flash -f efr32mg1b-v8-6910-115200.gbl -p socket://mygateway.local:19020 -d RAW -m xmodem
```
- Remote probe call
```
python Elelabs_EzspFwUtility.py probe -p socket://mygateway.local:19020 -d RAW
```